### PR TITLE
Clarify relay as primary and tail-style reads as legacy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ ccm tell "scheduled-tasks" "Please summarize your current frontend direction." -
 ccm open frontend-agent --listen-on "${KITTY_LISTEN_ON}" --cwd "$PWD"
 ```
 
+Visible-tab communication rule:
+
+- `ccm relay` is the primary path for tab-to-tab chat.
+- `ccm tell` is legacy raw injection only.
+- Reading raw tab text or pane tail is legacy debug-only evidence, not the normal collaboration path.
+
 ## Wechat-Style Peer Layer
 
 ```bash
@@ -81,7 +87,9 @@ codex-heartbeat test --tab-title mycel
 - If `ccm read` is empty or transcript resolution lags, run `ccm inspect <agent> --cwd "$PWD"` before guessing. It shows transcript search roots and recent pane tail.
 - Use `ccm read --raw --json` when you need unrendered transcript events for MCP/tool-trace debugging.
 - Use `ccm list --all-scopes --json` when the session you want may live in another saved namespace.
-- Prefer `ccm relay` over `ccm tell` when coordinating with another visible tab. `relay` auto-includes sender context and a reply hint.
+- Treat `ccm relay` as the primary path when coordinating with another visible tab. `relay` auto-includes sender context and a reply hint.
+- Treat `ccm tell` as legacy raw fire-and-forget injection only.
+- Treat raw tab text and pane tail as legacy debug evidence only. Tabs should normally talk through `relay`, not by reading each other's raw terminal output.
 - Remember the wakeup model: `ccm read` is poll-based tmux waiting; `ccm relay` is push-based kitty messaging. Polling Claude output will not wake another agent tab.
 - `codex-heartbeat start/status/stop/test` can all target a custom visible tab title with `--tab-title ...`. Use `test` for a one-shot push before you start a long-running heartbeat loop.
 - Use normal interactive Claude only. The main reason is to avoid drifting into non-interactive automation patterns that may be riskier for the account.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ ccm relay "feat/main-thread-for-member" "Use Claude to review the UI and report 
 
 `ccm tabs` now shows the peer tab title together with its resolved worktree, git branch, and agent identity. `ccm relay` wraps the message with a default envelope and a `reply-via` hint so a newcomer can answer without learning extra ceremony.
 
+Visible-tab communication rule:
+
+- `ccm relay` is the primary path for tab-to-tab chat.
+- `ccm tell` is a legacy raw path for rare fire-and-forget text injection.
+- reading raw tab text or pane tails is legacy debug-only evidence, not the normal way agents should talk to each other.
+
 This is also the wakeup-safe path for agents in visible tabs:
 
 - use `ccm read` when waiting on Claude agent output from the `tmux` layer

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,6 +203,12 @@ ccm relay "feat/main-thread-for-member" "Use Claude to review the UI and report 
 
 `ccm tabs` 现在会直接显示 peer 的 worktree、git branch 和 agent 身份。`ccm relay` 会自动包上一层默认 envelope 和 `reply-via` 提示，新人不需要自己记住上下文格式。
 
+visible tab 通信规则：
+
+- `ccm relay` 是 tab 之间聊天的主路径。
+- `ccm tell` 是 legacy 的原始文本注入路径，只留给极少数 fire-and-forget 场景。
+- 读取原始 tab 文本或 pane tail 只能算 legacy 的 debug 证据，不应作为 agent 正常对话方式。
+
 这也是 visible tab 里最安全的唤醒路径：
 
 - 等 `tmux` agent 输出时，用 `ccm read`

--- a/ccm_orchestra/cli.py
+++ b/ccm_orchestra/cli.py
@@ -2171,6 +2171,9 @@ def render_guide(audience: str) -> str:
         - `ccm relay` is push-based. It wakes another visible tab and gives it enough sender
           context to reply later.
         - Do not expect `read` to wake another agent tab for you.
+        - For visible-tab peer chat, `relay` is the primary path.
+        - Reading raw tab text or tmux pane tail is a legacy debug path, not a normal
+          collaboration path.
 
         Wechat-style peer layer:
         - Use direct targets such as `kitty:<tab-title>` and `tmux:<session-name>`.
@@ -2197,6 +2200,8 @@ def render_guide(audience: str) -> str:
         If `read` is empty or transcript resolution looks wrong:
         - run `ccm inspect frontend-agent --cwd "$PWD"`
         - look at the transcript search roots and pane tail before guessing
+        - treat pane tail as legacy debug evidence only; do not use raw tab text as the
+          normal way tabs talk to each other
 
         Heartbeat notes:
         - `codex-heartbeat start --tab-title mycel` keeps one named visible tab awake.
@@ -2212,6 +2217,11 @@ def render_guide(audience: str) -> str:
         - you are an agent inside kitty
         - you expect a useful reply or acknowledgment
         - the receiver needs sender identity, worktree, branch, agent, or scene context
+        - tab-to-tab chat should follow one primary path instead of falling back to raw text
+
+        Use `ccm tell` only when:
+        - you intentionally want a legacy raw fire-and-forget injection
+        - no sender envelope, reply hint, or receipt convention is needed
         """
     ).strip()
 
@@ -2228,7 +2238,8 @@ def build_parser() -> argparse.ArgumentParser:
             "not non-interactive print mode. Use 'open' only when the transcript is not "
             "enough: debugging a stuck agent, live observation, or deliberate visible-tab "
             "collaboration. For agents/LLMs, run 'ccm guide agent' for the longer operating "
-            "rules."
+            "rules. For visible-tab peer chat, use 'relay' as the primary path and treat raw "
+            "tab text/pane tail as legacy debug-only evidence."
         ),
     )
     parser.add_argument("--cwd", help="Select the session namespace directory; for start, also use it as the Claude cwd")
@@ -2263,7 +2274,8 @@ def build_parser() -> argparse.ArgumentParser:
         description=(
             "Inspect is the fallback when 'read' is empty or transcript resolution lags. "
             "It prints the session state path, tmux session, resolved transcript path, "
-            "transcript search roots, and a recent tmux pane tail."
+            "transcript search roots, and a recent tmux pane tail. Pane tail is legacy "
+            "debug evidence only, not the normal collaboration path between tabs."
         ),
     )
     inspect_parser.add_argument("name")
@@ -2326,7 +2338,15 @@ def build_parser() -> argparse.ArgumentParser:
     tabs_parser = subparsers.add_parser("tabs", help="kitty layer: list visible tabs and their resolved identity")
     tabs_parser.add_argument("--listen-on")
 
-    tell_parser = subparsers.add_parser("tell", help="kitty layer: send raw fire-and-forget text to a visible tab")
+    tell_parser = subparsers.add_parser(
+        "tell",
+        help="kitty layer: legacy raw fire-and-forget text to a visible tab",
+        description=(
+            "Tell is a legacy raw path. Prefer 'relay' for normal tab-to-tab chat, sender "
+            "context, and reply-friendly coordination. Use 'tell' only when you explicitly "
+            "want raw fire-and-forget text with no receipt convention."
+        ),
+    )
     tell_parser.add_argument("title")
     tell_parser.add_argument("message")
     tell_parser.add_argument("--listen-on")
@@ -2336,8 +2356,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="kitty layer: preferred for agents, send a message with sender context and reply hint",
         description=(
             "Prefer 'relay' over 'tell' when you are an agent inside kitty and expect a "
-            "useful reply. Relay wraps the message with sender identity and a reply hint. "
-            "Use 'tell' only for raw fire-and-forget text with no receipt convention."
+            "useful reply. Relay is the primary path for visible-tab peer chat. Relay wraps "
+            "the message with sender identity and a reply hint. Use 'tell' only for legacy "
+            "raw fire-and-forget text with no receipt convention."
         ),
     )
     relay_parser.add_argument("title")

--- a/docs/claude-codex-frontend-playbook.md
+++ b/docs/claude-codex-frontend-playbook.md
@@ -18,6 +18,12 @@ The wakeup model matters:
 
 If you need another agent to wake up and reply later, do not sit on `read` and hope. Use `relay`.
 
+Visible-tab communication rule:
+
+- `ccm relay` is the primary path for tab-to-tab chat.
+- `ccm tell` is a legacy raw path for rare fire-and-forget injection only.
+- raw tab text or pane tails are legacy debug-only evidence, not the normal collaboration path.
+
 ## Tooling
 
 - Claude session manager: `ccm`

--- a/docs/codex-claude-visible-collab-playbook.md
+++ b/docs/codex-claude-visible-collab-playbook.md
@@ -22,9 +22,11 @@ If you need another agent tab to wake up later, `relay` is the right primitive. 
 
 - `ccm`: manages interactive Claude Code sessions
 - `ccm tabs`: lists visible `kitty` tabs with resolved worktree, branch, and agent identity
-- `ccm tell`: low-level raw message injection into another visible `kitty` tab by title
-- `ccm relay`: collaboration-first messaging with sender envelope and `reply-via` hint
+- `ccm relay`: the primary path for visible-tab chat, with sender envelope and `reply-via` hint
+- `ccm tell`: legacy low-level raw message injection into another visible `kitty` tab by title
 - `codex-heartbeat`: keeps the supervising `main` tab awake
+
+Treat reading raw tab text or pane tails as legacy debug-only evidence, not as the normal way visible tabs should talk to each other.
 
 ## Rules
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -486,8 +486,18 @@ class ParserHelpTests(unittest.TestCase):
         help_text = relay_parser.format_help()
 
         self.assertIn("Prefer 'relay' over 'tell'", help_text)
+        self.assertIn("primary path", help_text)
         self.assertIn("reply hint", help_text)
         self.assertIn("no receipt convention", help_text)
+
+    def test_tell_help_marks_tell_as_legacy_raw_path(self):
+        parser = ccm.build_parser()
+        tell_parser = parser._subparsers._group_actions[0].choices["tell"]
+        help_text = tell_parser.format_help()
+
+        self.assertIn("legacy", help_text)
+        self.assertIn("raw fire-and-forget", help_text)
+        self.assertIn("Prefer 'relay'", help_text)
 
     def test_wechat_shift_help_mentions_phone_notice(self):
         parser = ccm.build_parser()
@@ -537,6 +547,9 @@ class GuideOutputTests(unittest.TestCase):
         self.assertIn("long-lived", guide_text)
         self.assertIn("dedicated", guide_text)
         self.assertIn("relay", guide_text)
+        self.assertIn("primary", guide_text)
+        self.assertIn("legacy", guide_text)
+        self.assertIn("raw tab text", guide_text)
         self.assertIn("push", guide_text)
         self.assertIn("poll", guide_text)
         self.assertIn("doctor", guide_text)
@@ -1992,9 +2005,12 @@ class InspectTests(unittest.TestCase):
 
     def test_inspect_help_mentions_pane_tail_and_transcript_debug(self):
         parser = ccm.build_parser()
-        help_text = parser.format_help()
+        inspect_parser = parser._subparsers._group_actions[0].choices["inspect"]
+        help_text = inspect_parser.format_help()
 
-        self.assertIn("inspect", help_text)
+        self.assertIn("pane tail", help_text)
+        self.assertIn("legacy", help_text)
+        self.assertIn("debug", help_text)
 
 
 class CleanupTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- mark `ccm relay` as the primary path for visible-tab peer chat across help text and docs
- mark `ccm tell` as a legacy raw path and pane-tail/raw-tab reading as legacy debug-only evidence
- tighten the agent guide and playbooks so tabs are expected to talk through relay rather than by reading raw terminal text

## Verification
- `cd /Users/lexicalmathical/Codebase/ccm-orchestra && python3 -m unittest tests.test_cli.ParserHelpTests tests.test_cli.GuideOutputTests`
- `cd /Users/lexicalmathical/Codebase/ccm-orchestra && python3 -m unittest tests.test_cli`
- `ccm relay --help | sed -n "1,80p"`
- `ccm tell --help | sed -n "1,80p"`
- `ccm guide agent | sed -n "1,120p"`

## Notes
- this is a docs/help-text tightening pass only; no runtime behavior changed
- the local installed `~/.local/share/ccm/ccm_orchestra/cli.py` was also synced so the active global `ccm` now shows the updated help text